### PR TITLE
IConsoleApplicationBuilder to inherit from IHostApplicationBuilder

### DIFF
--- a/src/ConsoleApplicationBuilder/ConsoleApplicationBuilder/DefaultConsoleApplicationBuilder.cs
+++ b/src/ConsoleApplicationBuilder/ConsoleApplicationBuilder/DefaultConsoleApplicationBuilder.cs
@@ -3,6 +3,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -158,6 +159,15 @@ internal class DefaultConsoleApplicationBuilder : IConsoleApplicationBuilder
 	/// <inheritsdoc />
 	public IHostEnvironment Environment { get; }
 
+	/// <inheritsdoc />
+	public IDictionary<object, object> Properties => new Dictionary<object, object>();
+
+	/// <inheritsdoc />
+	IConfigurationManager IHostApplicationBuilder.Configuration => Configuration;
+
+	/// <inheritsdoc />
+	public IMetricsBuilder Metrics => new SimpleMetricsBuilder(Services);
+
 	private sealed class LoggingBuilder(IServiceCollection services) : ILoggingBuilder
 	{
 		public IServiceCollection Services => services;
@@ -207,5 +217,10 @@ internal class DefaultConsoleApplicationBuilder : IConsoleApplicationBuilder
 		services.MakeReadOnly();
 
 		return serviceProvider.GetRequiredService<T>();
+	}
+
+	private sealed class SimpleMetricsBuilder(IServiceCollection services) : IMetricsBuilder
+	{
+		public IServiceCollection Services { get; } = services;
 	}
 }

--- a/src/ConsoleApplicationBuilder/ConsoleApplicationBuilder/IConsoleApplicationBuilder.cs
+++ b/src/ConsoleApplicationBuilder/ConsoleApplicationBuilder/IConsoleApplicationBuilder.cs
@@ -5,22 +5,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Pri.ConsoleApplicationBuilder;
 
-public interface IConsoleApplicationBuilder
+public interface IConsoleApplicationBuilder : IHostApplicationBuilder
 {
-	/// <summary>
-	/// Gets the set of key/value configuration properties.
-	/// </summary>
-	ConfigurationManager Configuration { get; }
-
-	/// <summary>
-	/// Gets a collection of services for the application to compose. This is useful for adding user provided or framework provided services.
-	/// </summary>
-	IServiceCollection Services { get; }
-
-	/// <summary>
-	/// Gets a collection of logging providers for the application to compose. This is useful for adding new logging providers.
-	/// </summary>
-	ILoggingBuilder Logging { get; }
 
 	/// <summary>
 	/// Builds the host. This method can only be called once.
@@ -28,19 +14,4 @@ public interface IConsoleApplicationBuilder
 	/// <returns>An initialized <see cref="T"/>.</returns>
 	T Build<T>() where T : class;
 
-	/// <summary>
-	/// Gets the information about the hosting environment an application is running in.
-	/// </summary>
-	IHostEnvironment Environment { get; }
-
-	/// <summary>
-	/// Registers a <see cref="IServiceProviderFactory{TContainerBuilder}" /> instance to be used to create the <see cref="IServiceProvider" />.
-	/// </summary>
-	/// <param name="factory">The factory object that can create the <typeparamref name="TContainerBuilder"/> and <see cref="IServiceProvider"/>.</param>
-	/// <param name="configure">
-	/// A delegate used to configure the <typeparamref name="TContainerBuilder" />. This can be used to configure services using
-	/// APIS specific to the <see cref="IServiceProviderFactory{TContainerBuilder}" /> implementation.
-	/// </param>
-	/// <typeparam name="TContainerBuilder">The type of builder provided by the <see cref="IServiceProviderFactory{TContainerBuilder}" />.</typeparam>
-	void ConfigureContainer<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory, Action<TContainerBuilder>? configure = null) where TContainerBuilder : notnull;
 }


### PR DESCRIPTION
Since lots of different facilities are extensions on IHostApplicationBuilder, changed the IConsoleApplicationBuilder to support this interface. 